### PR TITLE
feature: #11评论模块以及#33整合服务接口之间的调用

### DIFF
--- a/controller/comment.go
+++ b/controller/comment.go
@@ -3,45 +3,117 @@ package controller
 import (
 	"github.com/gin-gonic/gin"
 	"net/http"
+	"strconv"
+	"x-tiktok/dao"
+	"x-tiktok/service"
 )
 
 type CommentListResponse struct {
 	Response
-	CommentList []Comment `json:"comment_list,omitempty"`
+	CommentList []service.Comment `json:"comment_list,omitempty"`
 }
 
 type CommentActionResponse struct {
 	Response
-	Comment Comment `json:"comment,omitempty"`
+	Comment service.Comment `json:"comment,omitempty"`
 }
 
 // CommentAction no practical effect, just check if token is valid
 func CommentAction(c *gin.Context) {
-	token := c.Query("token")
-	actionType := c.Query("action_type")
-
-	if user, exist := usersLoginInfo[token]; exist {
-		if actionType == "1" {
-			text := c.Query("comment_text")
-			c.JSON(http.StatusOK, CommentActionResponse{Response: Response{StatusCode: 0},
-				Comment: Comment{
-					Id:         1,
-					User:       user,
-					Content:    text,
-					CreateDate: "05-01",
-				}})
+	// 获取userId
+	userId := c.GetInt64("userId")
+	videoId, err := strconv.ParseInt(c.Query("video_id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusOK, CommentActionResponse{
+			Response: Response{StatusCode: -1,
+				StatusMsg: "comment videoId json invalid"},
+		})
+		return
+	}
+	actionType, err := strconv.ParseInt(c.Query("action_type"), 10, 64)
+	if err != nil || actionType < 1 || actionType > 2 {
+		c.JSON(http.StatusOK, CommentActionResponse{
+			Response: Response{StatusCode: -1,
+				StatusMsg: "comment actionType json invalid"},
+		})
+		return
+	}
+	commentService := service.GetCommentServiceInstance()
+	switch {
+	// 评论
+	case actionType == 1:
+		content := c.Query("comment_text")
+		var comment dao.Comment
+		comment.UserId = userId
+		comment.VideoId = videoId
+		comment.Content = content
+		comment.ActionType = 1
+		commentRes, err := commentService.CommentAction(comment)
+		if err != nil {
+			c.JSON(http.StatusOK, CommentActionResponse{
+				Response: Response{StatusCode: -1,
+					StatusMsg: "comment failed"},
+			})
 			return
 		}
-		c.JSON(http.StatusOK, Response{StatusCode: 0})
-	} else {
-		c.JSON(http.StatusOK, Response{StatusCode: 1, StatusMsg: "User doesn't exist"})
+		c.JSON(http.StatusOK, CommentActionResponse{
+			Response: Response{StatusCode: 0,
+				StatusMsg: "comment success"},
+			Comment: commentRes,
+		})
+		return
+
+	// 取消评论
+	case actionType == 2:
+		commentId, err := strconv.ParseInt(c.Query("comment_id"), 10, 64)
+		if err != nil {
+			c.JSON(http.StatusOK, CommentActionResponse{
+				Response: Response{StatusCode: -1,
+					StatusMsg: "delete commentId invalid"},
+			})
+			return
+		}
+		err = commentService.DeleteCommentAction(commentId)
+		if err != nil {
+			c.JSON(http.StatusOK, CommentActionResponse{
+				Response: Response{StatusCode: -1,
+					StatusMsg: err.Error()},
+			})
+			return
+		}
+		c.JSON(http.StatusOK, CommentActionResponse{
+			Response: Response{StatusCode: 0,
+				StatusMsg: "delete commentId success"},
+		})
+		return
 	}
 }
 
 // CommentList all videos have same demo comment list
 func CommentList(c *gin.Context) {
+	userId := c.GetInt64("userId")
+	videoId, err := strconv.ParseInt(c.Query("video_id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusOK, CommentListResponse{
+			Response: Response{StatusCode: -1,
+				StatusMsg: "comment videoId json invalid"},
+		})
+		return
+	}
+	commentService := service.GetCommentServiceInstance()
+	commentList, err := commentService.GetCommentList(videoId, userId)
+	// 获取评论列表失败
+	if err != nil {
+		c.JSON(http.StatusOK, CommentListResponse{
+			Response: Response{StatusCode: -1,
+				StatusMsg: err.Error()},
+		})
+		return
+	}
+	// 获取评论列表成功
 	c.JSON(http.StatusOK, CommentListResponse{
 		Response:    Response{StatusCode: 0},
-		CommentList: DemoComments,
+		CommentList: commentList,
 	})
+	return
 }

--- a/controller/favorite.go
+++ b/controller/favorite.go
@@ -17,7 +17,7 @@ type GetFavouriteListResponse struct {
 	VideoList []service.Video `json:"video_list"`
 }
 
-// FavoriteAction 点赞操作
+// FavoriteAction 赞操作
 func FavoriteAction(c *gin.Context) {
 	videoId, _ := strconv.ParseInt(c.Query("video_id"), 10, 64)
 	actionType, _ := strconv.ParseInt(c.Query("action_type"), 10, 32)
@@ -42,26 +42,14 @@ func FavoriteAction(c *gin.Context) {
 	}
 }
 
-// FavoriteList 获取用户的点赞视频列表
+// FavoriteList 获取点赞列表
 func FavoriteList(c *gin.Context) {
 	strUserId := c.Query("user_id")
 	//likeCnt:=dao.VideoLikedCount()
 	userId, _ := strconv.ParseInt(strUserId, 10, 64)
 	Fni := service.NewLikeServImpInstance()
-
-	_, err := Fni.GetLikesList(userId)
-	//video类型数组的假数据
-	//var video_list []service.Video
-	videoList := make([]service.Video, 1, 2)
-	videoList[0].Id = 1
-	videoList[0].IsFavorite = true
-	videoList[0].AuthorId = 1
-	videoList[0].CoverUrl = ""
-	videoList[0].PlayUrl = ""
-	videoList[0].Title = ""
-	videoList[0].CommentCount = 10
-	videoList[0].FavoriteCount = 100
-	videoList[0].IsFavorite = true
+	// 返回视频列表信息
+	videoList, err := Fni.GetLikesList(userId)
 	if err == nil {
 		log.Printf("方法like.GetFavouriteList(userid) 成功")
 		c.JSON(http.StatusOK, GetFavouriteListResponse{

--- a/controller/feed.go
+++ b/controller/feed.go
@@ -32,7 +32,8 @@ func Feed(c *gin.Context) {
 	}
 	//log.Println("返回视频的最新投稿时间:", convTime)
 	// 获取登录用户的 id（等待用户模块存入用户id到context）
-	userId, _ := strconv.ParseInt(c.GetString("userId"), 10, 64)
+	//userId, _ := strconv.ParseInt(c.GetString("userId"), 10, 64)
+	userId := c.GetInt64("userId")
 	videoService := service.GetVideoServiceInstance()
 	videos, nextTime, err := videoService.Feed(convTime, userId)
 	if err != nil {

--- a/controller/publish.go
+++ b/controller/publish.go
@@ -18,6 +18,7 @@ type VideoListResponse struct {
 func Publish(c *gin.Context) {
 	token := c.PostForm("token")
 	log.Println("token:", token)
+	userId := c.GetInt64("userId")
 	data, err := c.FormFile("data")
 	if err != nil {
 		c.JSON(http.StatusOK, Response{
@@ -30,7 +31,6 @@ func Publish(c *gin.Context) {
 	log.Printf("视频 title: %v\n", title)
 	videoService := service.GetVideoServiceInstance()
 	// 从 token 中获取 userId
-	userId := c.GetInt64("userId")
 	err = videoService.Publish(data, title, userId)
 	if err != nil {
 		log.Println("上传文件失败")
@@ -49,8 +49,10 @@ func Publish(c *gin.Context) {
 
 // PublishList 用户的视频发布列表，直接列出用户所有投稿过的视频
 func PublishList(c *gin.Context) {
+	// 获取到的userId，被访问的用户id
 	reqUserId := c.Query("user_id")
 	userId, _ := strconv.ParseInt(reqUserId, 10, 64)
+	//userId := c.GetInt64("userId")
 	log.Println("获取到用户 Id：", userId)
 	token := c.Query("token")
 	log.Println("获取到用户 token：", token)

--- a/controller/user.go
+++ b/controller/user.go
@@ -10,21 +10,6 @@ import (
 	"x-tiktok/util"
 )
 
-// usersLoginInfo use map to store user info, and key is username+password for demo
-// user data will be cleared every time the server starts
-// test data: username=zhanglei, password=douyin
-var usersLoginInfo = map[string]User{
-	"zhangleidouyin": {
-		Id:            1,
-		Name:          "zhanglei",
-		FollowCount:   10,
-		FollowerCount: 5,
-		IsFollow:      true,
-	},
-}
-
-var userIdSequence = int64(1)
-
 type UserLoginResponse struct {
 	Response
 	UserId int64  `json:"user_id,omitempty"`
@@ -33,13 +18,13 @@ type UserLoginResponse struct {
 
 type UserResponse struct {
 	Response
-	User User `json:"user"`
+	User service.User `json:"user"`
 }
 
 func Register(c *gin.Context) {
 	username := c.Query("username")
 	password := c.Query("password")
-	usi := service.UserServiceImpl{}
+	usi := service.GetUserServiceInstance()
 	user := usi.GetUserBasicInfoByName(username)
 	if username == user.Name {
 		c.JSON(http.StatusOK, UserLoginResponse{
@@ -73,7 +58,7 @@ func Login(c *gin.Context) {
 	encoderPassword := service.EnCoder(password)
 	//log.Println("encoderPassword:", encoderPassword)
 	// 登录逻辑：使用jwt，根据用户信息生成token
-	usi := service.UserServiceImpl{}
+	usi := service.GetUserServiceInstance()
 
 	user := usi.GetUserBasicInfoByName(username)
 	userId := user.Id
@@ -95,7 +80,7 @@ func Login(c *gin.Context) {
 func UserInfo(c *gin.Context) {
 	userId := c.Query("user_id")
 	// 使用中间件，做token权限校验
-	usi := service.UserServiceImpl{}
+	usi := service.GetUserServiceInstance()
 	id, _ := strconv.ParseInt(userId, 10, 64)
 	if user, err := usi.GetUserLoginInfoById(id); err != nil {
 		c.JSON(http.StatusOK, UserResponse{
@@ -104,7 +89,7 @@ func UserInfo(c *gin.Context) {
 	} else {
 		c.JSON(http.StatusOK, UserResponse{
 			Response: Response{StatusCode: 0, StatusMsg: "Query Success"},
-			User:     User(user),
+			User:     user,
 		})
 	}
 }

--- a/dao/commentDao.go
+++ b/dao/commentDao.go
@@ -1,0 +1,70 @@
+package dao
+
+import (
+	"errors"
+	"log"
+	"time"
+)
+
+type Comment struct {
+	Id         int64     //评论id
+	UserId     int64     //评论用户id
+	VideoId    int64     //视频id
+	Content    string    //评论内容
+	ActionType int64     //发布评论为1，取消评论为2
+	CreatedAt  time.Time //评论发布的日期mm-dd
+	UpdatedAt  time.Time
+}
+
+// TableName 修改表名映射
+func (Comment) TableName() string {
+	return "comment"
+}
+
+func InsertComment(comment Comment) (Comment, error) {
+	if err := Db.Model(Comment{}).Create(&comment).Error; err != nil {
+		log.Println(err.Error())
+		return Comment{}, err
+	}
+	return comment, nil
+}
+
+func DeleteComment(commentId int64) error {
+	var comment Comment
+	// 先查询是否有此评论
+	result := Db.Where("id = ?", commentId).
+		First(&comment)
+	if result.Error != nil {
+		return errors.New("del comment is not exist")
+	}
+	// 删除评论，将action_type置为2
+	result = Db.Model(Comment{}).
+		Where("id=?", commentId).
+		Update("action_type", 2)
+	if result.Error != nil {
+		return result.Error
+	}
+	return nil
+}
+
+func GetCommentList(videoId int64) ([]Comment, error) {
+	var commentList []Comment
+	result := Db.Model(Comment{}).Where(map[string]interface{}{"video_id": videoId, "action_type": 1}).
+		Order("created_at desc").
+		Find(&commentList)
+	if result.Error != nil {
+		log.Println(result.Error)
+		return commentList, errors.New("get comment list failed")
+	}
+	return commentList, nil
+}
+
+func GetCommentCnt(videoId int64) (int64, error) {
+	var count int64
+	result := Db.Model(Comment{}).Where(map[string]interface{}{"video_id": videoId, "action_type": 1}).
+		Count(&count)
+	if result.Error != nil {
+		return 0, errors.New("find comments count failed")
+	}
+	return count, nil
+}

--- a/dao/commentDao_test.go
+++ b/dao/commentDao_test.go
@@ -1,0 +1,40 @@
+package dao
+
+import (
+	"log"
+	"testing"
+)
+
+func TestInsertComment(t *testing.T) {
+	var comment Comment = Comment{
+		UserId:  5,
+		VideoId: 14,
+		Content: "这条评论来自单元测试TestInsertComment",
+	}
+	commentRes, err := InsertComment(comment)
+	if err != nil {
+		log.Println(err)
+	}
+	log.Println("返回的评论是", commentRes)
+}
+
+func TestDeleteComment(t *testing.T) {
+	err := DeleteComment(1)
+	if err == nil {
+		log.Println("delete comment success")
+	}
+}
+
+func TestGetCommentList(t *testing.T) {
+	commentList, err := GetCommentList(21)
+	if err == nil {
+		log.Println(commentList)
+	}
+}
+
+func TestGetCommentCnt(t *testing.T) {
+	count, err := GetCommentCnt(21)
+	if err == nil {
+		log.Println(count)
+	}
+}

--- a/dao/likeDao_test.go
+++ b/dao/likeDao_test.go
@@ -15,24 +15,25 @@ func TestInsertLikeInfo(t *testing.T) {
 }
 
 func TestUpdateLikeInfo(t *testing.T) {
-	err := UpdateLikeInfo(152, 5, 1)
+	err := UpdateLikeInfo(5, 14, 1)
 	if err != nil {
-		return
+		log.Println(err)
 	}
 }
 
 func TestGetLikeListByUserId(t *testing.T) {
-	list, _, err := GetLikeListByUserId(152)
+	list, cnt, err := GetLikeListByUserId(5)
 	if err != nil {
 		log.Print(err.Error())
 	}
+	log.Println(cnt)
 	for _, v := range list {
 		fmt.Printf("%d\n", v)
 	}
 }
 
 func TestIsVideoLikedByUser(t *testing.T) {
-	islike, err := IsVideoLikedByUser(152, 5)
+	islike, err := IsVideoLikedByUser(5, 200)
 	if err != nil {
 		log.Print(err.Error())
 	}
@@ -40,7 +41,7 @@ func TestIsVideoLikedByUser(t *testing.T) {
 }
 
 func TestVideoLikedCount(t *testing.T) {
-	likeCnt, err := VideoLikedCount(9)
+	likeCnt, err := VideoLikedCount(20)
 	if err != nil {
 		log.Print(err.Error())
 	}
@@ -53,4 +54,12 @@ func TestGetLikeCountByUser(t *testing.T) {
 		log.Print(err.Error())
 	}
 	fmt.Printf("Like Count：%d\n", likeCnt)
+}
+
+func TestIsLikedByUser(t *testing.T) {
+	flag, err := IsLikedByUser(5, 23)
+	if err != nil {
+		log.Default()
+	}
+	log.Println(flag)
 }

--- a/dao/userDao.go
+++ b/dao/userDao.go
@@ -6,15 +6,14 @@ import (
 )
 
 type UserBasicInfo struct {
-	Id int64
-	Name string
-	Password string
+	Id        int64
+	Name      string
+	Password  string
 	CreatedAt time.Time `gorm:"CreatedAt" column:"CreatedAt"`
 	UpdatedAt time.Time `gorm:"CreatedAt" column:"UpdatedAt"`
 }
 
-
-func (user UserBasicInfo)TableName() string {
+func (user UserBasicInfo) TableName() string {
 	return "user"
 }
 
@@ -29,13 +28,13 @@ func InsertUser(user *UserBasicInfo) bool {
 func GetUserBasicInfoByName(name string) (UserBasicInfo, error) {
 	user := UserBasicInfo{}
 	if err := Db.Where("name = ?", name).First(&user).Error; err != nil {
-		log.Println(err.Error())
+		log.Println("获取用户信息读库失败", err.Error())
 		return user, err
 	}
 	return user, nil
 }
 
-func GetUserBasicInfoById(id int64) (UserBasicInfo, error){
+func GetUserBasicInfoById(id int64) (UserBasicInfo, error) {
 	user := UserBasicInfo{}
 	if err := Db.Where("id = ?", id).First(&user).Error; err != nil {
 		log.Println(err.Error())

--- a/dao/userDao_test.go
+++ b/dao/userDao_test.go
@@ -18,3 +18,9 @@ func TestGetUserBasicInfoByName(t *testing.T) {
 		log.Println(res)
 	}
 }
+
+func TestInsertUser(t *testing.T) {
+	user := UserBasicInfo{Name: "unit test", Password: "unit test"}
+	flag := InsertUser(&user)
+	log.Println(flag)
+}

--- a/dao/videoDao.go
+++ b/dao/videoDao.go
@@ -79,3 +79,27 @@ func GetVideoByVideoId(videoId int64) (Video, error) {
 	}
 	return video, nil
 }
+
+// GetVideoListById 根据videoIdList查询视频信息
+func GetVideoListById(videoIdList []int64) ([]Video, error) {
+	var videoList []Video
+	result := Db.Model(Video{}).
+		Where("id in (?)", videoIdList).
+		Find(&videoList)
+	if result.Error != nil {
+		return videoList, result.Error
+	}
+	return videoList, nil
+}
+
+func GetVideoCnt(userId int64) (int64, error) {
+	var count int64
+	result := Db.Model(Video{}).
+		Where("author_id = ?", userId).
+		Count(&count)
+	if result.Error != nil {
+		log.Println("根据userId获取作品数量失败！")
+		return -1, nil
+	}
+	return count, nil
+}

--- a/dao/videoDao_test.go
+++ b/dao/videoDao_test.go
@@ -37,4 +37,28 @@ func TestGetVideoByVideoId(t *testing.T) {
 	if err == nil {
 		log.Println(video)
 	}
+	// 耗时0.09s
+	for _, videoId := range []int64{15, 16, 17, 18, 19} {
+		video, _ := GetVideoByVideoId(videoId)
+		log.Println(video)
+	}
+}
+
+// 耗时0.02s
+func TestGetVideoListById(t *testing.T) {
+	videoList, err := GetVideoListById([]int64{15, 16, 17, 18, 19})
+	if err == nil {
+		log.Println(len(videoList))
+		//log.Println(videoList)
+	}
+	for _, video := range videoList {
+		log.Println(video)
+	}
+}
+
+func TestGetVideoCnt(t *testing.T) {
+	count, err := GetVideoCnt(5)
+	if err == nil {
+		log.Println(count)
+	}
 }

--- a/router.go
+++ b/router.go
@@ -22,8 +22,8 @@ func initRouter(r *gin.Engine) {
 	// 互动接口
 	apiRouter.POST("/favorite/action/", jwt.Auth(), controller.FavoriteAction)
 	apiRouter.GET("/favorite/list/", jwt.Auth(), controller.FavoriteList)
-	apiRouter.POST("/comment/action/", controller.CommentAction)
-	apiRouter.GET("/comment/list/", controller.CommentList)
+	apiRouter.POST("/comment/action/", jwt.Auth(), controller.CommentAction)
+	apiRouter.GET("/comment/list/", jwt.AuthWithoutLogin(), controller.CommentList)
 
 	// 社交接口
 	apiRouter.POST("/relation/action/", jwt.Auth(), controller.RelationAction)

--- a/service/commentService.go
+++ b/service/commentService.go
@@ -1,0 +1,23 @@
+package service
+
+import (
+	"x-tiktok/dao"
+)
+
+// CommentService 接口定义
+type CommentService interface {
+
+	// 给视频模块提供服务
+	GetCommentCnt(videoId int64) (int64, error)
+
+	CommentAction(comment dao.Comment) (Comment, error)
+	DeleteCommentAction(commentId int64) error
+	GetCommentList(videoId int64, userId int64) ([]Comment, error)
+}
+
+type Comment struct {
+	Id         int64  `json:"id"`
+	User       User   `json:"user"`
+	Content    string `json:"content"`
+	CreateDate string `json:"create_date"`
+}

--- a/service/commentServiceImpl.go
+++ b/service/commentServiceImpl.go
@@ -1,0 +1,90 @@
+package service
+
+import (
+	"log"
+	"sync"
+	"x-tiktok/config"
+	"x-tiktok/dao"
+)
+
+type CommentServiceImpl struct {
+	UserService
+}
+
+var (
+	commentServiceImpl *CommentServiceImpl
+	commentServiceOnce sync.Once
+)
+
+func GetCommentServiceInstance() *CommentServiceImpl {
+	commentServiceOnce.Do(func() {
+		commentServiceImpl = &CommentServiceImpl{
+			&UserServiceImpl{},
+		}
+	})
+	return commentServiceImpl
+}
+
+func (commentService *CommentServiceImpl) CommentAction(comment dao.Comment) (Comment, error) {
+	csi := GetCommentServiceInstance()
+	commentRes, err := dao.InsertComment(comment)
+	if err != nil {
+		return Comment{}, err
+	}
+	user, err := csi.GetUserLoginInfoById(comment.UserId)
+	if err != nil {
+		log.Println(err.Error())
+	}
+	commentData := Comment{
+		Id:         commentRes.Id,
+		User:       user,
+		Content:    commentRes.Content,
+		CreateDate: commentRes.CreatedAt.Format(config.GO_STARTER_TIME),
+	}
+	return commentData, nil
+}
+
+func (commentService *CommentServiceImpl) DeleteCommentAction(commentId int64) error {
+	return dao.DeleteComment(commentId)
+}
+
+func (commentService *CommentServiceImpl) GetCommentList(videoId int64, userId int64) ([]Comment, error) {
+	// 先根据videoId查评论id，再查用户信息
+	plainCommentList, err := dao.GetCommentList(videoId)
+	// 拿评论出错
+	if err != nil {
+		log.Println(err.Error())
+		return nil, err
+	}
+	n := len(plainCommentList)
+	//fmt.Println("视频评论的数量：", n)
+
+	commentInfoList := make([]Comment, 0, n)
+	for _, comment := range plainCommentList {
+		var commentData Comment
+		// 组合评论的用户信息
+		commentService.CombineComment(&commentData, &comment)
+		commentInfoList = append(commentInfoList, commentData)
+	}
+	return commentInfoList, nil
+}
+
+func (commentService *CommentServiceImpl) CombineComment(comment *Comment, plainComment *dao.Comment) error {
+	var wg sync.WaitGroup
+	commentServiceNew := GetCommentServiceInstance()
+	wg.Add(1)
+	user, err := commentServiceNew.GetUserLoginInfoById(plainComment.UserId)
+	if err != nil {
+		comment.User = user
+	}
+	comment.Id = plainComment.Id
+	comment.Content = plainComment.Content
+	comment.CreateDate = plainComment.CreatedAt.Format(config.GO_STARTER_TIME)
+	wg.Done()
+	wg.Wait()
+	return nil
+}
+
+func (commentService *CommentServiceImpl) GetCommentCnt(videoId int64) (int64, error) {
+	return dao.GetCommentCnt(videoId)
+}

--- a/service/commentService_test.go
+++ b/service/commentService_test.go
@@ -1,0 +1,44 @@
+package service
+
+import (
+	"fmt"
+	"log"
+	"testing"
+	"x-tiktok/dao"
+)
+
+func TestCommentServiceImpl_GetCommentCnt(t *testing.T) {
+	count, err := commentServiceImpl.GetCommentCnt(14)
+	if err != nil {
+		log.Default()
+	}
+	fmt.Println(count)
+}
+
+func TestCommentServiceImpl_CommentAction(t *testing.T) {
+	var comment dao.Comment = dao.Comment{
+		UserId:  5,
+		VideoId: 14,
+		Content: "这条评论来自单元测试TestInsertComment",
+	}
+	commentRes, err := commentServiceImpl.CommentAction(comment)
+	if err != nil {
+		log.Default()
+	}
+	fmt.Println(commentRes)
+}
+
+func TestCommentServiceImpl_DeleteCommentAction(t *testing.T) {
+	err := commentServiceImpl.DeleteCommentAction(1)
+	if err != nil {
+		log.Default()
+	}
+}
+
+func TestCommentServiceImpl_GetCommentList(t *testing.T) {
+	commentList, err := commentServiceImpl.GetCommentList(14, 5)
+	if err != nil {
+		log.Default()
+	}
+	fmt.Println(commentList)
+}

--- a/service/followService.go
+++ b/service/followService.go
@@ -18,7 +18,7 @@ type FollowService interface {
 	// GetFollowers 获取当前用户的粉丝列表
 	GetFollowers(userId int64) ([]User, error)
 	// GetFriends 获取好友
-	GetFriends(userId int64) ([]User, error)
+	GetFriends(userId int64) ([]FriendUser, error)
 	// GetFollowingCnt 根据用户id查询关注数
 	GetFollowingCnt(userId int64) (int64, error)
 	// GetFollowerCnt 根据用户id查询粉丝数

--- a/service/followServiceImpl.go
+++ b/service/followServiceImpl.go
@@ -10,7 +10,6 @@ import (
 
 // FollowServiceImp 该结构体继承FollowService接口。
 type FollowServiceImp struct {
-	FollowService
 	//MessageService
 }
 

--- a/service/likeService.go
+++ b/service/likeService.go
@@ -4,8 +4,8 @@ type LikeService interface {
 	// FavoriteAction 点赞操作
 	FavoriteAction(userId int64, videoId int64, actionType int32) error
 
-	//获取当前用户点赞列表
-	GetLikesList(userId int64) ([]int64, error)
+	// GetLikesList 获取当前用户点赞列表
+	GetLikesList(userId int64) ([]Video, error)
 	////获取视频列表
 	//GetVideo(videoId []int64, likeCnt int64) ([]Video, error)
 
@@ -13,6 +13,9 @@ type LikeService interface {
 	IsLikedByUser(userId int64, videoId int64) (bool, error)
 	// GetUserLikeCount 获取用户点赞数量
 	GetUserLikeCount(userId int64) (int64, error)
-	// GetVideoLikeCount 获取视频点赞数
-	GetVideoLikeCount(videoId int64) (int64, error)
+	// GetVideoLikedCount 获取视频点赞数
+	GetVideoLikedCount(videoId int64) (int64, error)
+
+	// GetUserLikedCnt 计算用户被点赞的视频获赞总数
+	GetUserLikedCnt(userId int64) (int64, error)
 }

--- a/service/likeServiceImpl.go
+++ b/service/likeServiceImpl.go
@@ -1,27 +1,28 @@
 package service
 
 import (
+	"errors"
 	"log"
 	"sync"
 	"time"
-	"x-tiktok/config"
 	"x-tiktok/dao"
 )
 
 type LikeServiceImpl struct {
-	LikeService
+	VideoService
 }
 
 var (
-	likeServiceImp    *LikeServiceImpl
-	likeServiceInstan sync.Once
+	likeServiceImp      *LikeServiceImpl
+	likeServiceInstance sync.Once
 )
 
 func NewLikeServImpInstance() *LikeServiceImpl {
-	likeServiceInstan.Do(
-		func() {
-			likeServiceImp = &LikeServiceImpl{}
-		})
+	likeServiceInstance.Do(func() {
+		likeServiceImp = &LikeServiceImpl{
+			VideoService: &VideoServiceImpl{},
+		}
+	})
 	return likeServiceImp
 }
 
@@ -29,23 +30,17 @@ func (*LikeServiceImpl) FavoriteAction(userId int64, videoId int64, actionType i
 	islike, err := dao.IsVideoLikedByUser(userId, videoId)
 	log.Print("islike:", islike)
 	log.Println("actionType:", actionType)
-	if err != nil {
-		if islike == -1 {
-			//用户没有点赞过该视频
-			//插入一条新记录
-			var likeinfo dao.Like
-			likeinfo.UserId = userId
-			likeinfo.VideoId = videoId
-			likeinfo.Liked = int8(actionType)
-			likeinfo.CreatedAt = time.Now()
-			likeinfo.UpdatedAt = time.Now()
-			err = dao.InsertLikeInfo(likeinfo)
-			return err
-		} else {
-			//查询失败
-			log.Print(err.Error())
-			return err
-		}
+	if islike == -1 {
+		//用户没有点赞过该视频
+		//插入一条新记录
+		var likeinfo dao.Like
+		likeinfo.UserId = userId
+		likeinfo.VideoId = videoId
+		likeinfo.Liked = int8(actionType)
+		likeinfo.CreatedAt = time.Now()
+		likeinfo.UpdatedAt = time.Now()
+		err = dao.InsertLikeInfo(likeinfo)
+		return nil
 	}
 	//该用户曾对此视频点过赞
 	err = dao.UpdateLikeInfo(userId, videoId, int8(actionType))
@@ -53,27 +48,27 @@ func (*LikeServiceImpl) FavoriteAction(userId int64, videoId int64, actionType i
 		log.Print(err.Error() + "Favorite action failed!")
 		return err
 	} else {
-		log.Print("Favorite action succed!")
+		log.Print("Favorite action succeed!")
 	}
 	return nil
 }
 
-// 获取点赞信息
-func (*LikeServiceImpl) GetLikesList(userId int64) ([]int64, error) {
-	//likelist, likeCnt, err := dao.GetLikeListByUserId(userId)
-	likelist, _, err := dao.GetLikeListByUserId(userId)
+// GetLikesList 获取点赞信息
+func (*LikeServiceImpl) GetLikesList(userId int64) ([]Video, error) {
+	likedVideoIdList, _, err := dao.GetLikeListByUserId(userId)
 	if err != nil {
 		log.Print("Get like list failed!")
 		return nil, err
 	}
-	//for i := 0; i < int(likeCnt); i++ {
-	//	//获取Video信息列表
-	//	//VideoService(.)
-	//}
-	return likelist, nil
+	likeService := NewLikeServImpInstance()
+	likedVideoInfoList, err := likeService.GetVideoListById(likedVideoIdList, userId)
+	if err != nil {
+		log.Println("Get videoList failed")
+	}
+	return likedVideoInfoList, nil
 }
 
-// 获取用户点赞数量
+// GetUserLikeCount 获取用户点赞数量
 func (*LikeServiceImpl) GetUserLikeCount(userId int64) (int64, error) {
 	_, likeCnt, err := dao.GetLikeListByUserId(userId)
 	if err != nil {
@@ -83,11 +78,10 @@ func (*LikeServiceImpl) GetUserLikeCount(userId int64) (int64, error) {
 	return likeCnt, nil
 }
 
-// 获取视频点赞数
-func (*LikeServiceImpl) GetVideoLikeCount(videoId int64) (int64, error) {
+// GetVideoLikedCount 获取视频点赞数
+func (*LikeServiceImpl) GetVideoLikedCount(videoId int64) (int64, error) {
 	//校验是否存在该视频
 	//？？？
-
 	likeCnt, err := dao.VideoLikedCount(videoId)
 	if err != nil {
 		log.Print("Get like count failed!")
@@ -96,18 +90,25 @@ func (*LikeServiceImpl) GetVideoLikeCount(videoId int64) (int64, error) {
 	return likeCnt, nil
 }
 
-// 当前用户是否点赞该视频
+// IsLikedByUser 当前用户是否点赞该视频
 func (*LikeServiceImpl) IsLikedByUser(userId int64, videoId int64) (bool, error) {
-	//先校验是否存在该用户
-	//？？？
-
-	liked, err := dao.IsVideoLikedByUser(userId, videoId)
+	liked, err := dao.IsLikedByUser(userId, videoId)
 	if err != nil {
-		log.Print("Get like info failed!")
 		return false, err
 	}
-	if liked == config.LIKE {
-		return true, nil
+	return liked, nil
+}
+
+// GetUserLikedCnt 计算用户被点赞的视频获赞总数
+func (*LikeServiceImpl) GetUserLikedCnt(userId int64) (int64, error) {
+	likeService := NewLikeServImpInstance()
+	likedVideoList, err := likeService.GetLikesList(userId)
+	if err != nil {
+		return -1, errors.New("获取用户点赞数失败")
 	}
-	return false, nil
+	var count int64 = 0
+	for _, video := range likedVideoList {
+		count += video.FavoriteCount
+	}
+	return count, nil
 }

--- a/service/likeService_test.go
+++ b/service/likeService_test.go
@@ -13,8 +13,8 @@ func TestLikeServiceImpl_FavoriteAction(t *testing.T) {
 	}
 }
 
-func TestGetVideoLikeCount(t *testing.T) {
-	likeCnt, err := likeServiceImp.GetVideoLikeCount(5)
+func TestGetVideoLikedCount(t *testing.T) {
+	likeCnt, err := likeServiceImp.GetVideoLikedCount(20)
 	if err != nil {
 		log.Default()
 	}
@@ -22,9 +22,25 @@ func TestGetVideoLikeCount(t *testing.T) {
 }
 
 func TestGetUserLikeCount(t *testing.T) {
-	likeCnt, err := likeServiceImp.GetUserLikeCount(1)
+	likeCnt, err := likeServiceImp.GetUserLikeCount(5)
 	if err != nil {
 		log.Default()
 	}
 	fmt.Println(likeCnt)
+}
+
+func TestLikeServiceImpl_IsLikedByUser(t *testing.T) {
+	liked, err := likeServiceImp.IsLikedByUser(5, 23)
+	if err != nil {
+		log.Default()
+	}
+	log.Println(liked)
+}
+
+func TestLikeServiceImpl_GetUserLikedCnt(t *testing.T) {
+	count, err := likeServiceImp.GetUserLikedCnt(5)
+	if err != nil {
+		log.Default()
+	}
+	log.Println(count)
 }

--- a/service/userService.go
+++ b/service/userService.go
@@ -4,24 +4,31 @@ import (
 	"x-tiktok/dao"
 )
 
-
 type UserService interface {
 
+	// GetUserBasicInfoById 根据Id获取用户的用户名和密码
 	GetUserBasicInfoById(id int64) dao.UserBasicInfo
 
+	// GetUserBasicInfoByName 根据用户名获取用户的用户名和密码
 	GetUserBasicInfoByName(name string) dao.UserBasicInfo
 
+	// GetUserLoginInfoById 根据用户id获取用户的详细信息（未登录）
 	GetUserLoginInfoById(id int64) (User, error)
 
+	// 根据用户id获取用户的详细信息 (登录)
+	GetUserLoginInfoByIdWithCurId(id int64, curId int64) (User, error)
+
+	// InsertUser 添加一个用户
 	InsertUser(user *dao.UserBasicInfo) bool
-
-
 }
 
 type User struct {
-	Id            int64  `json:"id"`
-	Name          string `json:"name"`
-	FollowCount   int64  `json:"follow_count"`
-	FollowerCount int64  `json:"follower_count"`
-	IsFollow      bool   `json:"is_follow"`
+	Id             int64  `json:"id"`
+	Name           string `json:"name"`
+	FollowCount    int64  `json:"follow_count"`
+	FollowerCount  int64  `json:"follower_count"`
+	IsFollow       bool   `json:"is_follow"`
+	TotalFavorited int64  `json:"total_favorited"`
+	FavoriteCount  int64  `json:"favorite_count"`
+	WorkCount      int64  `json:"work_count"`
 }

--- a/service/userServiceImpl.go
+++ b/service/userServiceImpl.go
@@ -4,7 +4,9 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"log"
+	"sync"
 	"x-tiktok/dao"
 )
 
@@ -12,7 +14,25 @@ type UserServiceImpl struct {
 	// 关注服务
 	FollowService
 	// 点赞服务
+	LikeService
+	// 视频服务
+	VideoService
+}
 
+var (
+	userServiceImp  *UserServiceImpl
+	userServiceOnce sync.Once
+)
+
+func GetUserServiceInstance() *UserServiceImpl {
+	userServiceOnce.Do(func() {
+		userServiceImp = &UserServiceImpl{
+			FollowService: &FollowServiceImp{},
+			LikeService:   &LikeServiceImpl{},
+			VideoService:  &VideoServiceImpl{},
+		}
+	})
+	return userServiceImp
 }
 
 func (usi *UserServiceImpl) GetUserBasicInfoById(id int64) dao.UserBasicInfo {
@@ -46,34 +66,82 @@ func (usi *UserServiceImpl) InsertUser(user *dao.UserBasicInfo) bool {
 	return true
 }
 
+// GetUserLoginInfoById 未登录情况返回用户信息
 func (usi *UserServiceImpl) GetUserLoginInfoById(id int64) (User, error) {
 	user := User{
-		Id:            5,
-		Name:          "qcj",
-		FollowCount:   1,
-		FollowerCount: 99999,
-		IsFollow:      false,
+		Id:             5,
+		Name:           "qcj",
+		FollowCount:    1,
+		FollowerCount:  99999,
+		IsFollow:       false,
+		TotalFavorited: 10,
+		FavoriteCount:  10,
+		WorkCount:      8,
 	}
 	u, err := dao.GetUserBasicInfoById(id)
+	fmt.Println(u)
 	if err != nil {
 		log.Println("Err:", err.Error())
 		log.Println("User Not Found")
 	}
+	userService := GetUserServiceInstance()
 	// 计算关注数
-
+	followCnt, _ := userService.GetFollowingCnt(id)
 	// 计算粉丝数
-
+	followerCnt, _ := userService.GetFollowerCnt(id)
 	// 计算作品数
+	workCount, _ := userService.GetVideoCnt(id)
+	// 计算被点赞数, 找出用户被点赞的视频，循环求和:在likeservide实现
+	totalFavorited, _ := userService.GetUserLikedCnt(id)
+	// 计算喜欢数量
+	favoriteCount, _ := userService.GetUserLikeCount(id)
+	user = User{
+		Id:             u.Id,
+		Name:           u.Name,
+		FollowCount:    followCnt,
+		FollowerCount:  followerCnt,
+		IsFollow:       false,
+		TotalFavorited: totalFavorited,
+		FavoriteCount:  favoriteCount,
+		WorkCount:      workCount,
+	}
 
-	// 计算喜欢数
+	return user, nil
+}
+
+// GetUserLoginInfoByIdWithCurId 登录情况下返回用户信息, 第一个id是视频作者的id，第二个id是我们用户的id
+func (usi *UserServiceImpl) GetUserLoginInfoByIdWithCurId(id int64, curId int64) (User, error) {
+	user := User{
+		Id:             5,
+		Name:           "qcj",
+		FollowCount:    1,
+		FollowerCount:  99999,
+		IsFollow:       false,
+		TotalFavorited: 10,
+		FavoriteCount:  10,
+		WorkCount:      8,
+	}
+	u, err := dao.GetUserBasicInfoById(id)
+	fmt.Println(u)
+	if err != nil {
+		log.Println("Err:", err.Error())
+		log.Println("User Not Found")
+	}
+	userService := GetUserServiceInstance()
+	// 计算关注数
+	followCnt, _ := userService.GetFollowingCnt(id)
+	// 计算粉丝数
+	followerCnt, _ := userService.GetFollowerCnt(id)
+	// 计算是否关注, 这个地方又有点奇怪？只有在当前登录的情况下关注作者，后面该作者的视频才会显示已关注；退出重新登录就没了！
+	isFollow, _ := userService.CheckIsFollowing(curId, id)
+	// 这里不计算作品数量，一是用不到，二是避免用户和视频循环依赖
 	user = User{
 		Id:            u.Id,
 		Name:          u.Name,
-		FollowCount:   1,
-		FollowerCount: 99999,
-		IsFollow:      false,
+		FollowCount:   followCnt,
+		FollowerCount: followerCnt,
+		IsFollow:      isFollow,
 	}
-
 	return user, nil
 }
 
@@ -84,6 +152,3 @@ func EnCoder(password string) string {
 	sha := hex.EncodeToString(h.Sum(nil))
 	return sha
 }
-
-
-

--- a/service/userService_test.go
+++ b/service/userService_test.go
@@ -1,0 +1,32 @@
+package service
+
+import (
+	"fmt"
+	"log"
+	"testing"
+	"x-tiktok/dao"
+)
+
+func TestUserServiceImpl_GetUserBasicInfoById(t *testing.T) {
+	userBasicInfo := userServiceImp.GetUserBasicInfoById(1)
+	fmt.Println(userBasicInfo)
+}
+
+func TestUserServiceImpl_GetUserBasicInfoByName(t *testing.T) {
+	userBasicInfo := userServiceImp.GetUserBasicInfoByName("qcj")
+	fmt.Println(userBasicInfo)
+}
+
+func TestUserServiceImpl_GetUserLoginInfoById(t *testing.T) {
+	userLoginInfo, err := userServiceImp.GetUserLoginInfoById(1)
+	if err != nil {
+		log.Default()
+	}
+	fmt.Println(userLoginInfo)
+}
+
+func TestUserServiceImpl_InsertUser(t *testing.T) {
+	user := dao.UserBasicInfo{Name: "unit test in service", Password: "unit test in service"}
+	flag := userServiceImp.InsertUser(&user)
+	fmt.Println(flag)
+}

--- a/service/videoService.go
+++ b/service/videoService.go
@@ -24,4 +24,10 @@ type VideoService interface {
 
 	// PublishList 查询用户 userId 所发布的所有视频
 	PublishList(userId int64) ([]Video, error)
+
+	// GetVideoCnt 根据用户id查询用户的作品数
+	GetVideoCnt(userId int64) (int64, error)
+
+	// GetVideoListById 查询videoId列表的视频信息
+	GetVideoListById(videoIdList []int64, userId int64) ([]Video, error)
 }

--- a/service/videoServiceImpl.go
+++ b/service/videoServiceImpl.go
@@ -14,6 +14,7 @@ import (
 
 type VideoServiceImpl struct {
 	UserService
+	CommentService
 	LikeService
 }
 
@@ -26,8 +27,9 @@ var (
 func GetVideoServiceInstance() *VideoServiceImpl {
 	videoServiceOnce.Do(func() {
 		videoServiceImp = &VideoServiceImpl{
-			UserService: &UserServiceImpl{},
-			LikeService: &LikeServiceImpl{},
+			UserService:    &UserServiceImpl{},
+			CommentService: &CommentServiceImpl{},
+			LikeService:    &LikeServiceImpl{},
 		}
 	})
 	return videoServiceImp
@@ -120,13 +122,17 @@ func (videoService *VideoServiceImpl) getRespVideos(videos *[]Video, plainVideos
 
 // 组装 controller 层所需的 Video 结构
 func (videoService *VideoServiceImpl) combineVideo(video *Video, plainVideo *dao.Video, userId int64) error {
-	// 建立协程组，确保所有协程的任务完成后才退出本方法
+	// 因为VideServiceImpl需要调用其他服务，所以需要通过New的方式给其调用服务初始化，不可直接用videoService
+	videoServiceNew := GetVideoServiceInstance()
+	// 解决循环依赖
+
+	//建立协程组，确保所有协程的任务完成后才退出本方法
 	var wg sync.WaitGroup
 	wg.Add(4)
 	video.Video = *plainVideo
-	// 视频作者信息
+	//视频作者信息
 	go func(v *Video) {
-		user, err := videoService.GetUserLoginInfoById(v.AuthorId)
+		user, err := videoServiceNew.GetUserLoginInfoByIdWithCurId(v.AuthorId, userId)
 		if err != nil {
 			return
 		}
@@ -136,27 +142,51 @@ func (videoService *VideoServiceImpl) combineVideo(video *Video, plainVideo *dao
 
 	// 视频点赞数量
 	go func(v *Video) {
-		// 等待点赞服务，获取视频点赞量
-		videoLikedCount, _ := videoService.GetVideoLikeCount(v.Video.Id)
-		v.FavoriteCount = videoLikedCount
+		//等待点赞服务，获取视频点赞量
+		favoriteCount, err := videoServiceNew.GetVideoLikedCount(v.Id)
+		if err != nil {
+			return
+		}
+		v.FavoriteCount = favoriteCount
 		wg.Done()
 	}(video)
 
 	// 视频评论数量
 	go func(v *Video) {
 		// 等待评论服务，获取视频评论量
-		v.CommentCount = 10
+		count, err := videoServiceNew.GetCommentCnt(v.Id)
+		if err != nil {
+			return
+		}
+		v.CommentCount = count
 		wg.Done()
 	}(video)
-
 	// 当前登录用户/游客是否对该视频点过赞
 	go func(v *Video) {
+		isFavorite, err := videoServiceNew.IsLikedByUser(userId, v.Id)
+		if err != nil {
+			return
+		}
 		// 等待点赞服务，获取是否点赞
-		isFavorite, _ := videoService.IsLikedByUser(userId, v.Id)
 		v.IsFavorite = isFavorite
 		wg.Done()
 	}(video)
 
 	wg.Wait()
 	return nil
+}
+
+func (videoService *VideoServiceImpl) GetVideoListById(videoIdList []int64, userId int64) ([]Video, error) {
+	videoList := make([]Video, 0, config.VIDEO_INIT_NUM_PER_AUTHOR)
+	plainVideoList, _ := dao.GetVideoListById(videoIdList)
+	err := videoService.getRespVideos(&videoList, &plainVideoList, userId)
+	if err != nil {
+		log.Println("getRespVideos:", err)
+		return nil, err
+	}
+	return videoList, nil
+}
+
+func (videoService *VideoServiceImpl) GetVideoCnt(userId int64) (int64, error) {
+	return dao.GetVideoCnt(userId)
 }

--- a/service/videoService_test.go
+++ b/service/videoService_test.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"fmt"
+	"log"
+	"testing"
+	"time"
+)
+
+func TestVideoServiceImpl_PublishList(t *testing.T) {
+	videoList, err := videoServiceImp.PublishList(1)
+	if err != nil {
+		log.Default()
+	}
+	fmt.Println(videoList)
+}
+
+func TestVideoServiceImpl_Feed(t *testing.T) {
+	videoList, nextTime, err := videoServiceImp.Feed(time.Now(), 1)
+	if err != nil {
+		log.Default()
+	}
+	fmt.Println(nextTime)
+	fmt.Println(videoList)
+}


### PR DESCRIPTION
videoService和likeService两个部分互相调用应该不会产生冲突，下面记录一下DeBug之旅：

* 错误描述：在视频服务和点赞服务接口之间函数调用导致视频流接口阻塞，体现在代码层面测试单元阻塞和接口301重定向

![image](https://user-images.githubusercontent.com/48522950/217526107-8242843c-78f9-4488-8614-b59f6190162c.png)

* 错误定位：一开始找了很久没找到！以为只要服务之间相互调用就会发生冲突，实则不然。今天在补充用户信息，用户服务和视频服务之间相互调用相安无事，于是乎就把之前视频和点赞调用函数的地方给重新梳理一遍，最终定位在此处：

<img width="737" alt="image" src="https://user-images.githubusercontent.com/48522950/217526877-a6d5e478-7c1d-4549-ac26-a1236275c9db.png">

* 错误分析：于是就疏离这个地方视频和点赞之间的调用关系，如下：

1. 点赞服务中

![image](https://user-images.githubusercontent.com/48522950/217527283-1d1ed6b4-919f-4f3b-8d78-dde1011fc980.png)

2. 视频服务中

![image](https://user-images.githubusercontent.com/48522950/217527321-cea3028c-ef63-43a5-a78f-9047771ea02a.png)

3. 点赞服务中

![image](https://user-images.githubusercontent.com/48522950/217527356-ee19e946-a144-442e-91e6-3ff3b052fb8b.png)

最终我怀疑是第三步出了问题，就进行一些列尝试，首先将Dao层函数调用给删掉，发现测试单元运行成功。初步判断会不会是读数据库冲突，重写了Dao函数。

![image](https://user-images.githubusercontent.com/48522950/217528344-bb9968cd-128f-4097-afaf-9081f4f709e7.png)

一开始我把`if result.RowsAffected == 0`的判断给去掉了，以为是改SQL语句的成功！好一阵子才反应过来，错误原来就在返回`fasle`的情况：没关注也是返回成功的，如果返回err的话，后续代码就阻塞调用这个函数的地方。

* 错误解决：

![image](https://user-images.githubusercontent.com/48522950/217529336-e6dd29a8-61f5-44a2-941f-b0397496aff5.png)


### 体会：
*  单元测试一定要写好
*  单元测试一定要写好
*  单元测试一定要写好






